### PR TITLE
Hyphens are allowed in TLD

### DIFF
--- a/src/Email.elm
+++ b/src/Email.elm
@@ -157,6 +157,7 @@ parseTld =
             (\a ->
                 Char.isUpper a
                     || Char.isLower a
+                    || (a == '-')
             )
         |> getChompedString
         |> andThen

--- a/tests/EmailTest.elm
+++ b/tests/EmailTest.elm
@@ -24,6 +24,7 @@ validEmailAddresses =
     , "example@s.example"
     , "example!#$%&'*+-/=?^_`{|}~@example.com"
     , "ab.c@example.com"
+    , "simple@com.plex-domain.org"
 
     -- The following email addresses are valid, but currently look like to big of an edge case to handle
     -- , "\" \"@example.org"


### PR DESCRIPTION
Validating email domains is hard. This isn't the perfect solution but, it does solve the issue of the example valid email, simple@com.plex-domain.org, failing to parse previously.
- Adds test for valid address with a hyphen in the domain
- Adds hyphen to TLD parser chompWhile